### PR TITLE
在大的分辨率下面，背景图片右侧出现一块空白。

### DIFF
--- a/src/views/login/index.vue
+++ b/src/views/login/index.vue
@@ -175,10 +175,11 @@
 
   .login-center-layout {
     background: #409EFF;
-    width: auto;
+    /* width: auto;
     height: auto;
     max-width: 100%;
-    max-height: 100%;
+    max-height: 100%; */
     margin-top: 200px;
+    width: 100%;
   }
 </style>


### PR DESCRIPTION
使登录页面的背景图片，占满屏幕的宽度。